### PR TITLE
[GITHUB-6] Allow Pool of Keyservers

### DIFF
--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -7,9 +7,8 @@
   get_url:
     dest: /tmp/elastic.asc
     mode: 0644
-    url: "{{ sansible_filebeat_repo_keyserver }}/pks/lookup?op=get&\
-      search=0x{{ sansible_filebeat_repo_key_id }}"
-  retries: 2
+    url: "{{ [sansible_filebeat_repo_keyserver] | flatten | random }}/pks/lookup?op=get&search=0x{{ sansible_filebeat_repo_key_id }}"
+  retries: 5
   delay: 10
   register: sansible_filebeat_pgp_result
   until: sansible_filebeat_pgp_result is succeeded


### PR DESCRIPTION
Allows to specify a list of keyservers as well as just one while keeping the interface the same, i. e. it accepts both

```yaml
sansible_filebeat_repo_keyserver: http://eu.pool.sks-keyservers.net
```

and

```yaml
sansible_filebeat_repo_keyserver: 
  - http://eu.pool.sks-keyservers.net
  - http://na.pool.sks-keyservers.net
  - http://oc.pool.sks-keyservers.net
```

In the latter case, a random keyserver from the list is picked.

Solves #6 